### PR TITLE
Pytorch Lightning protobuf fix

### DIFF
--- a/crypto_sentiment_demo_app/train/requirements-cpu.txt
+++ b/crypto_sentiment_demo_app/train/requirements-cpu.txt
@@ -1,4 +1,4 @@
--f https://download.pytorch.org/whl/torch_stable.html
+--extra-index-url https://download.pytorch.org/whl/cpu
 transformers==4.18.0
 datasets==2.0.0
 scikit-learn==1.0.2
@@ -10,3 +10,4 @@ skl2onnx==1.11.1
 onnxruntime==1.11.0
 torch==1.10.0
 pytorch-lightning==1.6.0
+protobuf<4.21.0

--- a/crypto_sentiment_demo_app/train/requirements-gpu.txt
+++ b/crypto_sentiment_demo_app/train/requirements-gpu.txt
@@ -1,4 +1,4 @@
--f https://download.pytorch.org/whl/torch_stable.html
+--extra-index-url https://download.pytorch.org/whl/cu113
 transformers==4.18.0
 datasets==2.0.0
 scikit-learn==1.0.2
@@ -10,3 +10,4 @@ skl2onnx==1.11.1
 onnxruntime==1.11.0
 torch==1.10.0+cu113
 pytorch-lightning==1.6.0
+protobuf<4.21.0


### PR DESCRIPTION
Пофиксил проблему с Pytorch Lightning, при которой в результате запуска сервиса для обучения моделей `COMPOSE_PROFILES=train USER=$(id -u) GROUP=$(id -g) docker-compose up --build` возникала ошибка при импортировании `from pytorch_lightning import Trainer, seed_everything`

```
train_1                | TypeError: Descriptors cannot not be created directly.
train_1                | If this call came from a _pb2.py file, your generated code is out of date and must be regenerated with protoc >= 3.19.0.
train_1                | If you cannot immediately regenerate your protos, some other possible workarounds are:
train_1                |  1. Downgrade the protobuf package to 3.20.x or lower.
train_1                |  2. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python parsing and will be much slower).
train_1                | 
train_1                | More information: https://developers.google.com/protocol-buffers/docs/news/2022-05-06#python-updates
```
Решается принудительным даунгрейдом пакета `protobuf<4.21.0`.

Также пофиксил проблему, когда при запуске CPU версии контейнера подтягивалась [ROCm-версия](https://pytorch.org/blog/pytorch-for-amd-rocm-platform-now-available-as-python-package/) пайторча, которая нам не нужна, но весит > 1гб вместо обычной CPU-only версии весом в 200мб.