### PR TITLE
redirect pycache files into tmp

### DIFF
--- a/crypto_sentiment_demo_app/crawler/Dockerfile
+++ b/crypto_sentiment_demo_app/crawler/Dockerfile
@@ -10,5 +10,6 @@ RUN pip3 install -r requirements.txt && python3 -m spacy download en \
     && python3 -m spacy download xx
 
 ENV PYTHONPATH "${PYTHONPATH}:/root/crypto_sentiment_demo_app"
+ENV PYTHONPYCACHEPREFIX=/tmp/cpython/
 
 COPY . /root

--- a/crypto_sentiment_demo_app/data_provider/Dockerfile
+++ b/crypto_sentiment_demo_app/data_provider/Dockerfile
@@ -11,5 +11,6 @@ RUN python -m pip install --upgrade pip
 RUN pip3 install -r requirements.txt
 
 ENV PYTHONPATH "${PYTHONPATH}:/root/crypto_sentiment_demo_app"
+ENV PYTHONPYCACHEPREFIX=/tmp/cpython/
 
 COPY . /root

--- a/crypto_sentiment_demo_app/label_studio/Dockerfile
+++ b/crypto_sentiment_demo_app/label_studio/Dockerfile
@@ -6,3 +6,4 @@ COPY requirements.txt /home/crypto_sentiment_demo_app
 RUN pip3 install -r /home/crypto_sentiment_demo_app/requirements.txt
 
 ENV PYTHONPATH "${PYTHONPATH}:/home/crypto_sentiment_demo_app"
+ENV PYTHONPYCACHEPREFIX=/tmp/cpython/

--- a/crypto_sentiment_demo_app/model_inference_api/Dockerfile
+++ b/crypto_sentiment_demo_app/model_inference_api/Dockerfile
@@ -16,5 +16,6 @@ RUN python -m pip install --upgrade pip
 RUN pip3 install -r requirements.txt
 
 ENV PYTHONPATH "${PYTHONPATH}:/root/crypto_sentiment_demo_app"
+ENV PYTHONPYCACHEPREFIX=/tmp/cpython/
 
 COPY . /root

--- a/crypto_sentiment_demo_app/model_scorer/Dockerfile
+++ b/crypto_sentiment_demo_app/model_scorer/Dockerfile
@@ -7,5 +7,6 @@ RUN python -m pip install --upgrade pip
 RUN pip3 install -r requirements.txt
 
 ENV PYTHONPATH "${PYTHONPATH}:/root/crypto_sentiment_demo_app"
+ENV PYTHONPYCACHEPREFIX=/tmp/cpython/
 
 COPY . /root

--- a/crypto_sentiment_demo_app/train/Dockerfile-cpu
+++ b/crypto_sentiment_demo_app/train/Dockerfile-cpu
@@ -27,3 +27,4 @@ RUN python -m pip install --upgrade pip
 RUN pip3 install -r requirements-cpu.txt --no-cache-dir
 
 ENV PYTHONPATH "${PYTHONPATH}:/root/crypto_sentiment_demo_app"
+ENV PYTHONPYCACHEPREFIX=/tmp/cpython/

--- a/crypto_sentiment_demo_app/train/Dockerfile-gpu
+++ b/crypto_sentiment_demo_app/train/Dockerfile-gpu
@@ -51,3 +51,4 @@ COPY requirements-gpu.txt /root
 RUN pip install -r requirements-gpu.txt --no-cache-dir
 
 ENV PYTHONPATH "${PYTHONPATH}:/root/crypto_sentiment_demo_app"
+ENV PYTHONPYCACHEPREFIX=/tmp/cpython/


### PR DESCRIPTION
Если добавить в переменную окружения `ENV PYTHONPYCACHEPREFIX=/tmp/cpython/` при билде докер-образа, то потом `__pycache__` сохраняется в самом докер-контейнере и не приходится каждый раз руками это дело удалять ([ссылка на документацию](https://docs.python.org/3/whatsnew/3.8.html#parallel-filesystem-cache-for-compiled-bytecode-files)). Локально потестил, всё ок.