### PR TITLE
remove uvicorn reload; deploy bert instead of tf-idf&logreg

### DIFF
--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -27,7 +27,7 @@ database:
 # Hydra logging boilerplate
 defaults:
   - _self_
-  - model: tf_idf
+  - model: bert
   - logger: base
   - override hydra/hydra_logging: disabled
   - override hydra/job_logging: disabled

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
   model_inference_api:
     image: basic_image_model_fast_api
     build: crypto_sentiment_demo_app/model_inference_api
-    command: uvicorn crypto_sentiment_demo_app.model_inference_api.api.model:app --host model_inference_api --port 8001 --reload
+    command: uvicorn crypto_sentiment_demo_app.model_inference_api.api.model:app --host model_inference_api --port 8001
     volumes:
       - ./:/root
     ports:
@@ -75,7 +75,7 @@ services:
   data_provider:
     image: basic_image_data_provider
     build: crypto_sentiment_demo_app/data_provider
-    command: uvicorn crypto_sentiment_demo_app.data_provider.api:app --host data_provider --port 8002 --reload
+    command: uvicorn crypto_sentiment_demo_app.data_provider.api:app --host data_provider --port 8002
     environment:
       - HOST=${HOST}
     ports:


### PR DESCRIPTION
Убрал `--reload` у `uvicorn` (касается сервисов с инференсом модели и дата провайдера) – заработало стабильно на всех тачках, причем перезапуски приложения не портят ситуацию.

Заодно выкатил берта, пока все норм. А то вот такие прогнозы логрега начали все же смущать. 
<img src="https://habrastorage.org/webt/_l/ne/cv/_lnecvthaqlob-cwujp14wxzm2m.png" width=70%/>

Берт для тех же примером намного четче прогнозы дает (anecdotal evidence).

Closes #34