### PR TITLE
Fix cron for model scorer

### DIFF
--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -27,7 +27,7 @@ database:
 # Hydra logging boilerplate
 defaults:
   - _self_
-  - model: tf_idf
+  - model: bert
   - logger: base
   - override hydra/hydra_logging: disabled
   - override hydra/job_logging: disabled

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - postgres
     labels:
       ofelia.enabled: "true"
-      ofelia.job-exec.crawler.schedule: "0 */6 * * *"   # At minute 0 past every 6th hour
+      ofelia.job-exec.crawler.schedule: "0 0 */6 * * *"   # At minute 0 past every 6th hour (Note: it starts with seconds, not minutes)
       ofelia.job-exec.crawler.command: "python3 -m crypto_sentiment_demo_app.crawler.crawler"
 
   model_inference_api:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - postgres
     labels:
       ofelia.enabled: "true"
-      ofelia.job-exec.crawler.schedule: "@every 6h"
+      ofelia.job-exec.crawler.schedule: "0 */6 * * *"   # At minute 0 past every 6th hour
       ofelia.job-exec.crawler.command: "python3 -m crypto_sentiment_demo_app.crawler.crawler"
 
   model_inference_api:
@@ -69,7 +69,7 @@ services:
       - postgres
     labels:
       ofelia.enabled: "true"
-      ofelia.job-exec.model_scorer.schedule: "@every 6h"
+      ofelia.job-exec.model_scorer.schedule: "15 */6 * * *"  # At minute 15 past every 6th hour.
       ofelia.job-exec.model_scorer.command: "python3 -m crypto_sentiment_demo_app.model_scorer.model_scorer"
 
   data_provider:
@@ -170,9 +170,9 @@ services:
       - postgres
     labels:
       ofelia.enabled: "true"
-      ofelia.job-exec.label_studio_import.schedule: "@every 6h"
+      ofelia.job-exec.label_studio_import.schedule: "30 */6 * * *" # At minute 30 past every 6th hour
       ofelia.job-exec.label_studio_import.command: "bash /home/crypto_sentiment_demo_app/crypto_sentiment_demo_app/label_studio/modify_tasks.sh -p crypto_label_project -m import -c entropy -n 8"
-      ofelia.job-exec.label_studio_export.schedule: "@every 6h"
+      ofelia.job-exec.label_studio_export.schedule: "59 23 * * *" # Everya day at 23:59
       ofelia.job-exec.label_studio_export.command: "bash /home/crypto_sentiment_demo_app/crypto_sentiment_demo_app/label_studio/modify_tasks.sh -p crypto_label_project -m export"
 
   db:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
   model_inference_api:
     image: basic_image_model_fast_api
     build: crypto_sentiment_demo_app/model_inference_api
-    command: uvicorn crypto_sentiment_demo_app.model_inference_api.api.model:app --host model_inference_api --port 8001 --reload
+    command: uvicorn crypto_sentiment_demo_app.model_inference_api.api.model:app --host model_inference_api --port 8001
     volumes:
       - ./:/root
     ports:
@@ -75,7 +75,7 @@ services:
   data_provider:
     image: basic_image_data_provider
     build: crypto_sentiment_demo_app/data_provider
-    command: uvicorn crypto_sentiment_demo_app.data_provider.api:app --host data_provider --port 8002 --reload
+    command: uvicorn crypto_sentiment_demo_app.data_provider.api:app --host data_provider --port 8002
     environment:
       - HOST=${HOST}
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,7 +69,7 @@ services:
       - postgres
     labels:
       ofelia.enabled: "true"
-      ofelia.job-exec.model_scorer.schedule: "15 */6 * * *"  # At minute 15 past every 6th hour.
+      ofelia.job-exec.model_scorer.schedule: "0 15 */6 * * *"  # At minute 15 past every 6th hour (Note: the format starts with seconds, instead of minutes.)
       ofelia.job-exec.model_scorer.command: "python3 -m crypto_sentiment_demo_app.model_scorer.model_scorer"
 
   data_provider:
@@ -170,9 +170,9 @@ services:
       - postgres
     labels:
       ofelia.enabled: "true"
-      ofelia.job-exec.label_studio_import.schedule: "30 */6 * * *" # At minute 30 past every 6th hour
+      ofelia.job-exec.label_studio_import.schedule: "0 30 */6 * * *" # At minute 30 past every 6th hour (Note: the format starts with seconds, instead of minutes)
       ofelia.job-exec.label_studio_import.command: "bash /home/crypto_sentiment_demo_app/crypto_sentiment_demo_app/label_studio/modify_tasks.sh -p crypto_label_project -m import -c entropy -n 8"
-      ofelia.job-exec.label_studio_export.schedule: "59 23 * * *" # Everya day at 23:59
+      ofelia.job-exec.label_studio_export.schedule: "0 59 23 * * *" # Every day at 23:59
       ofelia.job-exec.label_studio_export.command: "bash /home/crypto_sentiment_demo_app/crypto_sentiment_demo_app/label_studio/modify_tasks.sh -p crypto_label_project -m export"
 
   db:


### PR DESCRIPTION
Now `crawler`, `model_scorer`, and LabelStudio import are scheduled to run every 6 hours with a strict 15 gap between each over. Thus, `model_scorer` makes predictions for freshly scraped data, and LabelStudio imports the latest scored news. 

Also, we avoid this situation when `model_scorer` is not yet done but metrics for non-scored raw news titles are shown

<img src="https://habrastorage.org/webt/8v/wd/oy/8vwdoyvf6elf4ycmsqffrqf-jlm.jpeg" />

Also, LabelStudio export now runs every day at 23:59

Close #38 